### PR TITLE
記事詳細機能の実装

### DIFF
--- a/ArticleEditor/src/main/java/controller/Article.java
+++ b/ArticleEditor/src/main/java/controller/Article.java
@@ -36,9 +36,16 @@ public class Article extends HttpServlet{
 			int i = adao.delete(article_id);
 			if(i == 1) {
 				out.println("削除しました。");
-				RequestDispatcher rd = req.getRequestDispatcher("/top.html");
+				RequestDispatcher rd = req.getRequestDispatcher("/mypage.jsp");
 				rd.forward(req, res);
 			}
+		}else if(btn.equals("詳細")) {
+			System.out.println("サーブレットを使用");
+			int article_id = Integer.parseInt(req.getParameter("article_id"));
+			idto = adao.show(article_id);
+			req.setAttribute("idto", idto);
+			RequestDispatcher rd = req.getRequestDispatcher("/articles/show.jsp");
+			rd.forward(req, res);
 		}
 		
 

--- a/ArticleEditor/src/main/java/model/ArticleDAO.java
+++ b/ArticleEditor/src/main/java/model/ArticleDAO.java
@@ -119,6 +119,39 @@ public class ArticleDAO {
 	
 	
 	
+	public IndexDTO show(int article_id) {
+		Statement stmt = null;
+		ResultSet rs = null;
+		IndexDTO idto = new IndexDTO();
+		IndexBean ib = new IndexBean();
+		String sql = "SELECT title, text FROM articles WHERE article_id = " + article_id ;
+		
+		try {
+			connect();
+			stmt = con.createStatement();
+			rs = stmt.executeQuery(sql);
+			while(rs.next()) {
+				ib.setTitle(rs.getString("title"));
+				ib.setText(rs.getString("text"));
+				idto.add(ib);
+			}
+			
+		}catch(Exception e) {
+			e.printStackTrace();
+		}finally {
+			try {
+				if(rs != null) rs.close();
+				if(stmt != null) stmt.close();
+			}catch(Exception e) {
+				e.printStackTrace();
+			}
+		}
+		disconnect();
+		return idto;
+	}
+	
+	
+	
 	
 	public void disconnect() {
 		try {

--- a/ArticleEditor/src/main/webapp/articles/index.jsp
+++ b/ArticleEditor/src/main/webapp/articles/index.jsp
@@ -37,7 +37,10 @@
 			<tr>
 				<td><%= ib.getTitle() %></td>
 				<td>
-					<button type="button" onclick="location.href='/ArticleEditor/articles/show.jsp'">詳細</button>
+					<form action="/ArticleEditor/article" method="post">
+						<input type="hidden" name="article_id" value="<%= Integer.toString(ib.getArticle_id()) %>">
+						<input type="submit" name="btn" value="詳細">
+					</form>
 				</td>
 			</tr>
 			<% } %>

--- a/ArticleEditor/src/main/webapp/articles/show.jsp
+++ b/ArticleEditor/src/main/webapp/articles/show.jsp
@@ -1,12 +1,18 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
+<%@page import="bean.articles.*" %>
+<jsp:useBean id="idto" class="bean.articles.IndexDTO" scope="request"></jsp:useBean>
 <!DOCTYPE html>
 <html>
 <head>
 <meta charset="UTF-8">
-<title>Insert title here</title>
+<title>記事詳細画面</title>
 </head>
 <body>
-
+	<% for(int i = 0; i < idto.size(); i++){ %>
+	<% IndexBean ib = idto.get(i); %>
+	<h1><%= ib.getTitle() %></h1>
+	<h2><%= ib.getText() %></h2>
+	<% } %>
 </body>
 </html>


### PR DESCRIPTION
## 記事のタイトルとテキストを表示する機能を実装
- 記事一覧画面から、詳細画面を選択
- 記事のIDが取得され、DBから同じIDを持つ記事のタイトル、テキストを取得し、表示する。