### PR TITLE
マイページからの記事詳細機能、記事作成機能の実装

### DIFF
--- a/ArticleEditor/src/main/java/controller/Article.java
+++ b/ArticleEditor/src/main/java/controller/Article.java
@@ -9,8 +9,10 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import bean.articles.IndexDTO;
+import bean.users.AccountBean;
 import model.ArticleDAO;
 
 @WebServlet("/article")
@@ -40,12 +42,27 @@ public class Article extends HttpServlet{
 				rd.forward(req, res);
 			}
 		}else if(btn.equals("詳細")) {
-			System.out.println("サーブレットを使用");
+			System.out.println("記事詳細を利用");
 			int article_id = Integer.parseInt(req.getParameter("article_id"));
 			idto = adao.show(article_id);
 			req.setAttribute("idto", idto);
 			RequestDispatcher rd = req.getRequestDispatcher("/articles/show.jsp");
 			rd.forward(req, res);
+		}else if(btn.equals("記事作成")) {
+			System.out.println("記事作成を利用");
+			String title = req.getParameter("title");
+			String text = req.getParameter("text");
+		
+			HttpSession session = req.getSession(true);
+			 AccountBean returnAb = (AccountBean)session.getAttribute("returnAb");
+			int user_id = returnAb.getUser_id();
+			
+			int i = adao.create(title, text, user_id);
+			if(i == 1) {
+				System.out.println("記事を作成しました。");
+				RequestDispatcher rd = req.getRequestDispatcher("/top.html");
+				rd.forward(req, res);
+			}
 		}
 		
 

--- a/ArticleEditor/src/main/java/model/ArticleDAO.java
+++ b/ArticleEditor/src/main/java/model/ArticleDAO.java
@@ -96,6 +96,11 @@ public class ArticleDAO {
 		return executeSql(sql);
 	}
 	
+	public int create(String title, String text, int user_id) {
+		String sql = "INSERT INTO articles(title, text, user_id) VALUES('" + title + "','" + text + "'," + user_id + ")";
+		return executeSql(sql);
+	}
+	
 	
 	public int executeSql(String sql) {
 		Statement stmt = null;

--- a/ArticleEditor/src/main/webapp/articles/create.jsp
+++ b/ArticleEditor/src/main/webapp/articles/create.jsp
@@ -1,0 +1,21 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>記事作成画面</title>
+</head>
+<body>
+	<h1>記事作成画面</h1>
+	<form action="/ArticleEditor/article" method="post">
+		タイトル：<br>
+		<input type="text" name="title" size="50" maxlength="10" required><br>
+		本文：<br>
+		<textarea name="text" cols="50" rows="2" maxlength="3000" required></textarea><br>
+		
+		<input type="submit" name="btn" value="記事作成">
+		<button type="button">下書き保存</button>
+	</form>
+</body>
+</html>

--- a/ArticleEditor/src/main/webapp/mypage.jsp
+++ b/ArticleEditor/src/main/webapp/mypage.jsp
@@ -11,6 +11,9 @@
 </head>
 <body>
 	<h2>ようこそ<%= name %>さん</h2>
+	<form action="/ArticleEditor/articles/create.jsp" method="post">
+		<input type="submit" name="btn" value="記事作成">
+	</form>
 	<h3>記事数：<%= idto.size() %></h3>
 	<table>
 		<thead>
@@ -25,7 +28,10 @@
 			<tr>
 				<td><%= ib.getTitle() %></td>
 				<td>
-					<button type="button" onclick="location.href='/ArticleEditor/articles/show.jsp'">詳細</button>
+					<form action="/ArticleEditor/article" method="post">
+						<input type="hidden" name="article_id" value="<%= Integer.toString(ib.getArticle_id()) %>">
+						<input type="submit" name="btn" value="詳細">
+					</form>
 				</td>
 				<td>
 					<button type="button">編集</button>


### PR DESCRIPTION
## マイページかららの記事詳細画面への遷移
- 記事一覧画面に記載したフォームと同様のものをマイページにも実装
## ユーザが記事を新しく作成する機能を実装
- マイページから `記事作成` ボタンで記事作成画面へ遷移する
- ユーザIDを持った記事を作成することができる。
- フォーム画面で入力数制限を行うことで、エラーを減らす。